### PR TITLE
[np] fetch fallbacks reported through issues

### DIFF
--- a/back/cache_dir/annotations_cache_manager.js
+++ b/back/cache_dir/annotations_cache_manager.js
@@ -22,7 +22,7 @@ module.exports = {
                     fs.writeFileSync(`${__dirname}/annotations/${id.substring(0, 11)}.xml`, xml)
                     callback(xml)
                 })
-            })
+            }).catch(error => {callback("")})
         }
     },
 

--- a/back/cache_dir/ryd_cache_manager.js
+++ b/back/cache_dir/ryd_cache_manager.js
@@ -32,6 +32,9 @@ module.exports = {
                     callback(utils.custom_rating_round(response.rating))
                     cache[id] = utils.custom_rating_round(response.rating)
                 })
+            }).catch(error => {
+                console.log("[e] return youtube dislike api failed to load!", error)
+                callback(5)
             })
         }
     },

--- a/back/yt2009channels.js
+++ b/back/yt2009channels.js
@@ -378,6 +378,16 @@ module.exports = {
                             callback(data)
                         }
                     })
+                }).catch(e => {
+                    fs.writeFileSync(`../assets/${data.newBanner}`, "")
+                    delete data.banner;
+                    delete data.newBanner;
+                    delete data.bannerUrl;
+                    additionalFetchesCompleted++;
+                    if(additionalFetchesCompleted >= fetchesRequired) {
+                        callback(data)
+                    }
+                    return;
                 })
             }
             catch(error) {
@@ -1466,6 +1476,11 @@ module.exports = {
                         setChannelIcon()
                         markAsDone()
                     }
+                }).catch(e => {
+                    // error pulling old icon, use current
+                    fs.writeFileSync(fname, "")
+                    setChannelIcon()
+                    markAsDone()
                 })
             }
         }
@@ -1526,6 +1541,10 @@ module.exports = {
                         }
                         
                     }
+                }).catch(e => {
+                    // bg pull fail, use default
+                    fs.writeFileSync(bgfile, "")
+                    c()
                 })
             } else if(fs.existsSync(bgfile) && fs.statSync(bgfile).size > 5) {
                 // use downloaded background
@@ -1560,6 +1579,9 @@ module.exports = {
                     // doesn't exist, download current
                     downCurrent()
                 }
+            }).catch(e => {
+                // can't pull, use current
+                downCurrent()
             })
 
             // failed :( get current banner
@@ -1579,6 +1601,14 @@ module.exports = {
                             templates.banner(`${`/assets/${cId}_banner.jpg`}`)
                         )
                         getOldBg("404")
+                    })
+                }).catch(e => {
+                    fetch(data.bannerUrl.replace("googleusercontent", "ggpht"), {
+                        "headers": yt2009constants.headers
+                    }).then(r => {
+                        fs.writeFileSync(`../assets/${cId}_banner.jpg`, "")
+                        getOldBg()
+                        return;
                     })
                 })
             }
@@ -1814,7 +1844,7 @@ module.exports = {
                                     userHandle = m;
                                 }
                             })
-                        } else {
+                        } else if(r.header.c4TabbedHeaderRenderer.channelHandleText) {
                             userHandle = r.header.c4TabbedHeaderRenderer
                                           .channelHandleText.runs[0].text
                         }

--- a/back/yt2009html.js
+++ b/back/yt2009html.js
@@ -338,25 +338,12 @@ module.exports = {
                             [data.author_img.split("/").length - 1]
                 if(!fs.existsSync(`../assets/${fname}.png`)
                 && data.author_img !== "default") {
-                    fetch(data.author_img, {
-                        "headers": constants.headers
-                    }).then(r => {
-                        r.buffer().then(buffer => {
-                            fs.writeFileSync(`../assets/${fname}.png`, buffer)
-                            fetchesCompleted++;
-                            if(fetchesCompleted >= 3) {
-                                callback(data)
-                            }
-                            
-                        })
-                    })
-                } else {
-                    fetchesCompleted++;
-                    if(fetchesCompleted >= 3) {
-                        callback(data)
-                    }
+                    data.author_img = yt2009utils.saveAvatar(data.author_img, false)
                 }
-                data.author_img = `/assets/${fname}.png`
+                fetchesCompleted++;
+                if(fetchesCompleted >= 3) {
+                    callback(data)
+                }
             
 
                 // fetch comments

--- a/back/yt2009utils.js
+++ b/back/yt2009utils.js
@@ -513,11 +513,22 @@ module.exports = {
         }
         fname = fname.replace(".png", "")
         if(!fs.existsSync(`../assets/${fname}.png`)) {
-            fetch(link, {
+            fetch(link.replace("ggpht.com", "googleusercontent.com"), {
                 "headers": constants.headers
             }).then(r => {
                 r.buffer().then(buffer => {
                     fs.writeFileSync(`../assets/${fname}.png`, buffer)
+                })
+            }).catch(e => {
+                console.log("googleusercontent load fail! trying ggpht")
+                fetch(link, {
+                    "headers": constants.headers
+                }).then(r => {
+                    r.buffer().then(buffer => {
+                        fs.writeFileSync(`../assets/${fname}.png`, buffer)
+                    })
+                }).catch(e => {
+                    console.log("attempt 2 of loading user avatar fail!", link)
                 })
             })
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt2009",
-  "version": "1.13.0.1",
+  "version": "1.13.0.2",
   "description": "2009 frontend for youtube",
   "main": "back/backend.js",
   "scripts": {


### PR DESCRIPTION
- fix potential crashing when trying to load a topic channel with auto_user.

fetch calls with fallbacks (would normally crash yt2009):
- RYD api will return 5 stars on failures and logs the failed request (#84) (thanks, zjzjaqka!)
- fallbacks have been put in place when googleusercontent/ggpht fail. (#4, #85) (thanks, VictorFilimonov!)
- annotations (pulled from archive.org) will send empty responses if fail.