### PR TITLE
various minor changes

### DIFF
--- a/back/geo/world-chart-data.json
+++ b/back/geo/world-chart-data.json
@@ -19,6 +19,8 @@
     "GY": "rectangle 146,115 148,122",
     "GF": "rectangle 154,118 155,120",
     "SR": "rectangle 150,117 152,120",
+    "GL": "rectangle 130,0 206,8 rectangle 146,9 207,33",
+    "AR": "rectangle 137,165 149,186 rectangle 149,169 151,172 rectangle 137,163 147,165 rectangle 138,161 145,163 rectangle 133,186 146,209 rectangle 131,201 133,207",
 
 
     "IE": "rectangle 209,41 213,42",

--- a/back/language_data/en.json
+++ b/back/language_data/en.json
@@ -313,5 +313,11 @@
     "userpage_vl_table_rating": "Rating",
     "vl_permalink_label": "Playlist/URL (Permalink):",
     "vl_embed_label": "Embeddable Player:",
-    "vl_playall": "Play All Videos"
+    "vl_playall": "Play All Videos",
+    "channelpage_all": "All Channels",
+    "channelpage_pages": "Pages: ",
+    "channelpage_prev": "Previous",
+    "channelpage_next": "Next",
+    "channelpage_type": "Channel",
+    "channelpage_subs": " Subscribers"
 }

--- a/back/language_data/pl.json
+++ b/back/language_data/pl.json
@@ -319,5 +319,11 @@
     "userpage_vl_table_rating": "Ocena",
     "vl_permalink_label": "Playlista/adres URL (link bezpośredni):",
     "vl_embed_label": "Odtwarzacz osadzony na stronie:",
-    "vl_playall": "Odtwórz wszystkie filmy wideo"
+    "vl_playall": "Odtwórz wszystkie filmy wideo",
+    "channelpage_all": "Wszystkie kanały",
+    "channelpage_pages": "Strony: ",
+    "channelpage_prev": "Poprzednia",
+    "channelpage_next": "Następna",
+    "channelpage_type": "Kanał",
+    "channelpage_subs": " Subskrybentów"
 }

--- a/back/yt2009captions.js
+++ b/back/yt2009captions.js
@@ -98,6 +98,11 @@ module.exports = {
                                 })
                                 .then(r => {r.text().then(r => {
                                     if(r.includes(defaults[0])) {
+                                        if(retryCount < 2) {
+                                            retryCount++
+                                            getFile(true)
+                                            return;
+                                        }
                                         r = defaults[1]
                                     }
                                     callback(r)

--- a/back/yt2009channelspage.js
+++ b/back/yt2009channelspage.js
@@ -12,6 +12,7 @@ const channels = require("./yt2009channels")
 const utils = require("./yt2009utils")
 const templates = require("./yt2009templates")
 const doodles = require("./yt2009doodles")
+const languages = require("./language_data/language_engine")
 
 module.exports = {
     "apply": function(req, res) {
@@ -42,8 +43,8 @@ module.exports = {
         // shows tab
         if(req.headers.cookie.includes("shows_tab")) {
             code = code.replace(
-                `<a href="/channels">Channels</a>`,
-                `<a href="/channels">Channels</a><a href="#">Shows</a>`
+                `<a href="/channels">lang_channels</a>`,
+                `<a href="/channels">lang_channels</a><a href="#">lang_shows</a>`
             )
         }
 
@@ -76,7 +77,7 @@ module.exports = {
         let pagingHTML = `
         <div class="searchFooterBox">
             <div class="pagingDiv">
-                <span class="pagerLabel smallText label">Pages: </span>`
+                <span class="pagerLabel smallText label">lang_channelpage_pages</span>`
         let pageNumbers = [
             pageNumber - 2,
             pageNumber - 1,
@@ -85,7 +86,7 @@ module.exports = {
             pageNumber + 2
         ]
         if(pageNumbers[1] >= 1) {
-            pagingHTML += `<a href="?p=${pageNumber - 1}" class="pagerNotCurrent">Previous</a>`
+            pagingHTML += `<a href="?p=${pageNumber - 1}" class="pagerNotCurrent">lang_channelpage_prev</a>`
         }
         let addedPages = []
         pageNumbers.forEach(page => {
@@ -104,7 +105,7 @@ module.exports = {
             addedPages.push(lastPage + 1)
             pagingHTML += `<a href="?p=${p}" class="pagerNotCurrent">${p}</a>`
         }
-        pagingHTML += `<a href="?p=${pageNumber + 1}" class="pagerNotCurrent">Next</a>`
+        pagingHTML += `<a href="?p=${pageNumber + 1}" class="pagerNotCurrent">lang_channelpage_next</a>`
         pagingHTML += `
             </div>
         </div>`
@@ -112,6 +113,7 @@ module.exports = {
         // final
         code = code.replace(`<!--yt2009_channels_insert-->`, channelsHTML + pagingHTML)
         code = doodles.applyDoodle(code)
+        code = languages.apply_lang_to_code(code, req)
 
         res.send(code)
     }

--- a/back/yt2009cps.js
+++ b/back/yt2009cps.js
@@ -4,6 +4,7 @@ const search = require("./yt2009search")
 const html = require("./yt2009html")
 const channels = require("./yt2009channels")
 const mobileauths = require("./yt2009mobileauths")
+const yt2009jsongdata = require("./yt2009jsongdata")
 
 module.exports = {
     "get_search": function(req, res) {
@@ -41,6 +42,13 @@ module.exports = {
         }
 
         let page = ((req.query["start-index"] || 0) / 20)
+
+        // jsongdata
+        if(req.query.alt == "json") {
+            yt2009jsongdata.search(req, res)
+            return;
+        }
+
         /*
         =======
         create the search XML

--- a/back/yt2009html.js
+++ b/back/yt2009html.js
@@ -1202,6 +1202,7 @@ https://web.archive.org/web/20091111/http://www.youtube.com/watch?v=${data.id}`
                 req.headers.cookie.split("alt_swf_path=")[1].split(";")[0]
             )
             if(!swfFilePath) {swfFilePath = "/watch.swf"}
+            swfFilePath = swfFilePath.split(`"`).join(`%22`)
         }
         if(req.headers.cookie.includes("alt_swf_arg")) {
             swfArgPath = decodeURIComponent(
@@ -1210,6 +1211,7 @@ https://web.archive.org/web/20091111/http://www.youtube.com/watch?v=${data.id}`
             if(!swfArgPath) {
                 swfArgPath = "video_id"
             }
+            swfArgPath = swfArgPath.split(`"`).join(`%22`)
         }
         let flash_url = `${swfFilePath}?${swfArgPath}=${data.id}`
         if((req.headers["cookie"] || "").includes("f_h264")) {
@@ -1220,6 +1222,18 @@ https://web.archive.org/web/20091111/http://www.youtube.com/watch?v=${data.id}`
         && req.headers.cookie.includes("f_compat=")) {
             flashCompat = req.headers.cookie.split("f_compat=")[1].split(";")[0]
             flash_url += "&rt=" + Date.now()
+        }
+        let flashCustomModules = {
+            "iv": false,
+            "cc": false
+        }
+        if(req.headers.cookie
+        && req.headers.cookie.includes("f_civ=")) {
+            flashCustomModules.iv = req.headers.cookie.split("f_civ=")[1].split(";")[0]
+        }
+        if(req.headers.cookie
+        && req.headers.cookie.includes("f_ccc=")) {
+            flashCustomModules.cc = req.headers.cookie.split("f_ccc=")[1].split(";")[0]
         }
         if(useFlash) {
             code = code.replace(
@@ -2025,6 +2039,7 @@ https://web.archive.org/web/20091111/http://www.youtube.com/watch?v=${data.id}`
                     flash_url += "&vq=" + vq
                 }
                 let enableModules = !flashCompat.includes("modules")
+                let customModulesPath = ""
                 if(new Date().getMonth() == 3
                 && new Date().getDate() == 1
                 && !req.headers.cookie.includes("unflip=1")) {
@@ -2062,8 +2077,15 @@ https://web.archive.org/web/20091111/http://www.youtube.com/watch?v=${data.id}`
                     flash_url += "&fmt_url_map=" + encodeURIComponent(fmtUrls)
                 }
                 
+                let ccModuleAs2 = encodeURIComponent(
+                    `http://${config.ip}:${config.port}/subtitle-module.swf`
+                )
+                let ivModuleAs2 = encodeURIComponent(
+                    `http://${config.ip}:${config.port}/iv_module.swf`
+                )
                 if(enableModules) {
-                    flash_url += `&cc_module=http%3A%2F%2F${config.ip}%3A${config.port}%2Fsubtitle-module.swf`
+                    flash_url += `&cc_module=${flashCustomModules.cc || ccModuleAs2}`
+                    flash_url += `&iv_module=${flashCustomModules.iv || ivModuleAs2}`
                 }
 
                 // always_captions flash

--- a/back/yt2009jsongdata.js
+++ b/back/yt2009jsongdata.js
@@ -1,0 +1,213 @@
+const fetch = require("node-fetch")
+const utils = require("./yt2009utils")
+const search = require("./yt2009search")
+const html = require("./yt2009html")
+const cfg = require("./config.json")
+const feedBase = {
+    "version": "1.0",
+    "encoding": "UTF-8",
+    "feed": {
+        "entry": [],
+        "author": [{
+            "name": {"$t": "YouTube"},
+            "uri": {"$t": "http://www.youtube.com"}
+        }],
+        "category": [{
+            "scheme": "http://schemas.google.com/g/2005#kind",
+            "term": "http://gdata.youtube.com/schemas/2007#video"
+        }],
+        "generator": {
+            "$t": "YouTube data API",
+            "uri": "http://gdata.youtube.com",
+            "version": "2.1"
+        },
+        "id": {"$t": "tag:youtube.com,2008:videos"},
+        "logo": {"$t": "http://www.gstatic.com/youtube/img/logo.png"},
+        "title": {"$t": "Videos"},
+        "updated": {"$t": "2024-08-30T19:54:35.068Z"},
+        "xmlns": "http://www.w3.org/2005/Atom",
+        "xmlns$app": "http://www.w3.org/2007/app",
+        "xmlns$gd": "http://schemas.google.com/g/2005",
+        "xmlns$georss": "http://www.georss.org/georss",
+        "xmlns$gml": "http://www.opengis.net/gml",
+        "xmlns$media": "http://search.yahoo.com/mrss/",
+        "xmlns$openSearch": "http://a9.com/-/spec/opensearch/1.1/",
+        "xmlns$yt": "http://gdata.youtube.com/schemas/2007"
+    }
+}
+function jsonVideo(v) {
+    let author = (v.author_handle || v.author_name)
+    let base = "http://" + cfg.ip + ":" + cfg.port
+    let e = {
+        "author": {
+            "name": {"$t": author},
+            "uri": {
+                "$t": base + "/feeds/api/users/" + author
+            }
+        },
+        "category": [
+            {
+                "scheme": "http://schemas.google.com/g/2005#kind",
+                "term": "http://gdata.youtube.com/schemas/2007#video"
+            },
+            {
+                "label": v.category || "-",
+                "scheme": "http://gdata.youtube.com/schemas/2007/categories.cat",
+                "term": v.category || "-"
+            }
+        ],
+        "content": {
+            "src": "http://" + cfg.ip + ":" + cfg.port + "/watch.swf?video_id" + v.id,
+            "type": "application/x-shockwave-flash"
+        },
+        "gd$comments": {
+            "gd$feedLink": base + "/feeds/api/videos/" + v.id + "/comments",
+            "rel": "http://gdata.youtube.com/schemas/2007#comments",
+            "countHint": 1
+        },
+        "id": {
+            "$t": "tag:youtube.com,2008:video:" + v.id
+        },
+        "link": [
+            {
+                "href": "http://www.youtube.com/watch?v=" + v.id,
+                "rel": "alternate",
+                "type": "text/html"
+            },
+            {
+                "href": base + "/feeds/api/videos/" + v.id,
+                "rel": "http://gdata.youtube.com/schemas/2007#video.related",
+                "type": "application/atom+xml"
+            }
+        ],
+        "media$group": {
+            "media$category": {
+                "label": v.category || "-",
+                "scheme": "http://gdata.youtube.com/schemas/2007/categories.cat",
+                "term": v.category || "-"
+            },
+            "media$content": [{
+                "duration": v.length || 2,
+                "medium": "video",
+                "yt$format": 5,
+                "url": base + "/get_video?video_id=" + v.id + "/mp4"
+            }],
+            "media$credit": [{
+                "$t": author,
+                "role": "uploader",
+                "scheme": "urn:youtube",
+                "yt$display": author
+            }],
+            "media$description": {"$t": v.description},
+            "media$keywords": {},
+            "media$license": {
+                "$t": "youtube",
+                "href": "http://www.youtube.com/t/terms",
+                "type": "text/html"
+            },
+            "media$player": {"url": "http://www.youtube.com/watch?v=" + v.id},
+            "media$thumbnail": [
+                {"height": 90, "width": 120, time: "00:00:00",
+                "url": "//i.ytimg.com/vi/" + v.id + "/default.jpg"},
+                {"height": 180, "width": 320, time: "00:00:00",
+                "url": "//i.ytimg.com/vi/" + v.id + "/mqdefault.jpg"},
+                {"height": 360, "width": 480, time: "00:00:00",
+                "url": "//i.ytimg.com/vi/" + v.id + "/hqdefault.jpg"},
+                {"height": 480, "width": 360, time: "00:00:00",
+                "url": "//i.ytimg.com/vi/" + v.id + "/sddefault.jpg"},
+                {"height": 90, "width": 120, time: "00:00:00",
+                "url": "//i.ytimg.com/vi/" + v.id + "/1.jpg"},
+                {"height": 90, "width": 120, time: "00:00:00",
+                "url": "//i.ytimg.com/vi/" + v.id + "/2.jpg"},
+                {"height": 90, "width": 120, time: "00:00:00",
+                "url": "//i.ytimg.com/vi/" + v.id + "/3.jpg"}
+            ],
+            "media$title": {"$t": v.title, "type": "plain"},
+            "yt$duration": {"seconds": v.length || "999"},
+            "yt$uploaded": {"$t": new Date(
+                utils.relativeToAbsoluteApprox(v.upload)
+            ).toISOString()},
+            "yt$videoid": {"$t": v.id}
+        },
+        "published": {"$t": new Date(
+            utils.relativeToAbsoluteApprox(v.upload)
+        ).toISOString()},
+        "updated": {"$t": new Date(
+            utils.relativeToAbsoluteApprox(v.upload)
+        ).toISOString()},
+        "y9$rupload": v.upload,
+        "title": {"$t": v.title},
+        "yt$hd": {}
+    }
+    if(v.author_url.includes("/channel/")) {
+        e.author["yt$userId"] = {"$t": v.author_url.replace("/channel/UC", "")}
+        e.media$group.yt$uploaderId = {"$t": v.author_url.replace("/channel/UC", "")}
+    }
+    if(v.upload && v.upload.includes("-") && v.upload.includes("T")) {
+        e.media$group.yt$uploaded.$t = v.upload
+        e.published = v.upload
+        e.updated = v.upload
+        delete e.y9$rupload;
+    }
+    return e;
+}
+
+module.exports = {
+    "search": function(req, res) {
+        res.set("content-type", "text/plain")
+        let data = JSON.parse(JSON.stringify(feedBase))
+        let callback = false;
+        if(req.query.callback) {
+            callback = req.query.callback;
+        }
+        if(!req.query.q) {
+            res.sendStatus(400);
+            return;
+        }
+        let results = 20
+        let addedResults = 0;
+        if(req.query["max-results"] && !isNaN(parseInt(req.query["max-results"]))) {
+            results = parseInt(req.query["max-results"])
+        }
+        let order = "relevance"
+        let page = ((req.query["start-index"] || 0) / 20)
+
+        function addVideosToResponse(videos) {
+            videos.forEach(v => {
+                if(JSON.stringify(html.get_cache_video(v.id)) !== "{}") {
+                    v = JSON.parse(JSON.stringify(html.get_cache_video(v.id)))
+                    v.type = "video"
+                }
+                if(v.type == "video") {
+                    data.feed.entry.push(jsonVideo(v))
+                    addedResults++;
+                }
+            })
+            if(callback) {
+                res.send(callback + "(" + JSON.stringify(data) + ")")
+            } else {
+                res.send(JSON.stringify(data))
+            }
+        }
+
+        search.get_search(
+            encodeURIComponent(req.query.q) || "", "",
+            {"page": page},
+            (results => {
+                let first3Videos = []
+                results.forEach(video => {
+                    if(video.type !== "video") return;
+                    if(first3Videos.length < 3) {
+                        first3Videos.push(video.id)
+                    }
+                })
+
+                // add videos when preloading done
+                html.bulk_get_videos(first3Videos, () => {
+                    addVideosToResponse(results)
+                })
+            }),
+            utils.get_used_token(req) + "-jsongdata", false
+        )
+    }
+}

--- a/back/yt2009mobile.js
+++ b/back/yt2009mobile.js
@@ -12,6 +12,7 @@ const yt2009playlists = require("./yt2009playlists")
 const mobileflags = require("./yt2009mobileflags")
 const yt2009_exports = require("./yt2009exports")
 const mobileauths = require("./yt2009mobileauths")
+const yt2009jsongdata = require("./yt2009jsongdata")
 const env = config.env
 const rtsp_server = `rtsp://${config.ip}:${config.port + 2}/`
 const ffmpeg_process_144 = [
@@ -789,8 +790,12 @@ module.exports = {
                 id = mobileflags.get_flags(req).login_simulate.split("/")[1]
             }
         }
+        let path = "/@" + id
+        if(id.startsWith("UC") && id.length == 24) {
+            path = "/channel/" + id
+        }
         let flags = mobileflags.get_flags(req).channel
-        channels.main({"path": "/@" + id, 
+        channels.main({"path": path, 
         "headers": {"cookie": ""},
         "query": {"f": 0}}, 
         {"send": function(data) {
@@ -805,7 +810,7 @@ module.exports = {
                 if(data.videoCount) {
                     videoCount = data.videoCount
                 } else {
-                    channels.fill_videocount("/@" + id, (count) => {
+                    channels.fill_videocount(path, (count) => {
                         if(count !== "") {
                             videoCount = count;
                         }
@@ -838,7 +843,11 @@ module.exports = {
         if(!mobileauths.isAuthorized(req, res, "feed")) return;
         let id = req.originalUrl.split("/users/")[1]
                                 .split("/uploads")[0]
-        channels.main({"path": "/@" + id, 
+        let path = "/@" + id
+        if(id.startsWith("UC") && id.length == 24) {
+            path = "/channel/" + id
+        }
+        channels.main({"path": path, 
         "headers": {"cookie": ""},
         "query": {"f": 0}}, 
         {"send": function(data) {
@@ -875,8 +884,12 @@ module.exports = {
         if(!mobileauths.isAuthorized(req, res, "feed")) return;
         let id = req.originalUrl.split("/users/")[1]
                                 .split("/playlists")[0]
+        let path = "/@" + id
+        if(id.startsWith("UC") && id.length == 24) {
+            path = "/channel/" + id
+        }
         setTimeout(function() {
-            channels.main({"path": "/@" + id, 
+            channels.main({"path": path,
             "headers": {"cookie": ""},
             "query": {"f": 0}}, 
             {"send": function(data) {
@@ -907,8 +920,12 @@ module.exports = {
         if(!mobileauths.isAuthorized(req, res, "feed")) return;
         let id = req.originalUrl.split("/users/")[1]
                                 .split("/playlists")[0]
+        let path = "/@" + id
+        if(id.startsWith("UC") && id.length == 24) {
+            path = "/channel/" + id
+        }
         setTimeout(function() {
-            channels.main({"path": "/@" + id, 
+            channels.main({"path": path, 
             "headers": {"cookie": ""},
             "query": {"f": 0}}, 
             {"send": function(data) {
@@ -971,9 +988,14 @@ module.exports = {
         }
 
         // i do love being too lazy to develop this function properly
+        let path = "/@" + req.query.author
+        if(req.query.author.startsWith("UC")
+        && req.query.author.length == 24) {
+            path = "/channel/" + path
+        }
         require("./yt2009subscriptions").fetch_new_videos({
             "headers": {
-                "url": "/@" + req.query.author
+                "url": path
             },
             "query": {
                 "flags": ""

--- a/back/yt2009mobileauths.js
+++ b/back/yt2009mobileauths.js
@@ -55,6 +55,19 @@ module.exports = {
             return true;
         }
 
+        // classic site-based auth
+        if(req.headers.cookie && req.headers.cookie.includes("auth=")) {
+            let a = req.headers.cookie.split("auth=")[1].split(";")[0].trim()
+            if((config.tokens && config.tokens.includes(a))
+            && (!config.templocked_tokens
+            || !config.templocked_tokens.includes(a))) {
+                if(useTShare) {
+                    require("./yt2009ts").add(req)
+                }
+                return true;
+            }
+        }
+
         // header-based auth: mobile apps
         if((!deviceId && !token)
         || !gdataAuths[deviceId]

--- a/back/yt2009templates.js
+++ b/back/yt2009templates.js
@@ -978,9 +978,9 @@ module.exports = {
                             </div>
                         </div>
                         <div class="channel-facets">
-                            <span class="result-type">Channel</span>
+                            <span class="result-type">lang_channelpage_type</span>
                             <span class="channel-video-count"></span>
-                            <span>${channel.properties.subscribers ? channel.properties.subscribers : "0"} <span class="channel-text-break-grid"></span>Subscribers</span>
+                            <span>${channel.properties.subscribers ? channel.properties.subscribers : "0"} <span class="channel-text-break-grid"></span>lang_channelpage_subs</span>
                             <span class="channel-username"><a class="hLink" href="${channel.url}">${channelName}</a></span>
                         </div>
                     </div>

--- a/channels.htm
+++ b/channels.htm
@@ -22,22 +22,22 @@
 				<form autocomplete="off" class="search-form" action="/results" method="get" name="searchForm">
 					<input id="masthead-search-term" class="search-term" name="search_query" type="text" tabindex="1" value="" maxlength="128">
 					<input id="search-type-masthead" name="search_type" type="hidden" value="">
-					<a class="yt-button yt-button-primary" id="" style="" href="#"><span>Search</span></a>
+					<a class="yt-button yt-button-primary" id="" style="" href="#"><span>lang_search</span></a>
 				</form>
 			</div>
 			<div id="masthead-utility">
 				<!--yt2009_login_insert-->
 			</div>
 			<div id="masthead-nav-user">
-				<a href="/watch_queue?all" id="quicklist-nav" style="display: none;">0</span>)</a>
-				<a href="/my_subscriptions?masthead=1">Subscriptions</a>
-				<a href="/my_history">History</a>
-				<a class="yt-button yt-button-urgent yt-button-short" id="" style="" href="/my_videos_upload"><span>Upload</span></a>
+				<a href="/watch_queue" id="quicklist-nav" style="background-color: rgb(255, 255, 255);" class="hid">lang_quicklist (<span id="quicklist-nav-count">?</span>)</a>
+				<a href="/my_subscriptions?masthead=1">lang_subs_btn</a>
+				<a href="/my_history">lang_history_btn</a>
+				<a class="yt-button yt-button-urgent yt-button-short" id="" class href="/my_videos_upload"><span>lang_upload_btn</span></a>
 			</div>
 			<div id="masthead-nav-main">
-				<a href="/">Home</a>
-				<a href="/videos">Videos</a>
-				<a href="/channels">Channels</a>
+				<a href="/">lang_home</a>
+				<a href="/videos">lang_videos</a>
+				<a href="/channels">lang_channels</a>
 			</div>
 			<div id="masthead-end"></div>
 		</div>
@@ -93,15 +93,15 @@
 		<div id="body-column">
 			<div class="main-tab-layout-top-browse-tabs">
 				<div class="browse-tab-modifiers yt-rounded">
-					<div class="subcategory first yt-rounded"><a href="/videos">Videos</a></div>
-					<div class="subcategory selected">Channels</div>
+					<div class="subcategory first yt-rounded"><a href="/videos">lang_videos</a></div>
+					<div class="subcategory selected">lang_channels</div>
 					<div class="clear"></div>
 				</div>
 			</div>
 			<table class="browse-modifiers-extended" width="100%">
 				<tr>
 					<td class="browse-modifiers-extended-category" width="20%">
-						<span class="browse-modifiers-extended-category-lbl">In:</span> All Channels
+						<span class="browse-modifiers-extended-category-lbl">lang_in_cat</span> All Channels
 					</td>
 					<!--<td class="browse-basic-modifiers" width="60%">
 						<div class="subcategory first yt-rounded selected">
@@ -126,73 +126,73 @@
 		<div id="footer">
 			<div class="search">
 				<form autocomplete="off" class="search-form" action="/results" method="get" name="footer-search-form">
-					<input id="footer-search-term" class="search-term" name="search_query" type="text">
+					<input id="footer-search-term" class="search-term" name="search_query" type="text" value="" maxlength="128">
 					<input id="search-type-footer" name="search_type" type="hidden" value="">
-					<a class="yt-button yt-button-primary" id="" style="" href="#"><span>Search</span></a>
+					<a class="yt-button yt-button-primary" id="" style="" href="#" onclick="document['footer-search-form'].submit();"><span>lang_search</span></a>
 				</form>
 			</div>
 			<div class="links">
 				<table cellpadding="0" cellspacing="0">
 					<tr>
-						<th>YouTube</th>
-						<th>Programs</th>
-						<th>Help</th>
-						<th>Policy</th>
-						<th>Discover</th>
+						<th>lang_footer_yt</th>
+						<th>lang_footer_programs</th>
+						<th>lang_footer_help</th>
+						<th>lang_footer_policy</th>
+						<th>lang_footer_discover</th>
 					</tr>
 					<tr>
-						<td><a href="/t/contact_us">Contact Us</a></td>
-						<td><a href="/t/advertising">Advertising</a></td>
-						<td><b><a href="http://www.google.com/support/youtube/bin/static.py?page=start.cs&amp;hl=en-US" target="_blank">Get Help</a></b></td>
-						<td><a href="/t/privacy">Privacy Policy</a></td>
-						<td><a href="/mobile">YouTube on Your Phone</a></td>
+						<td><a href="/t/contact_us">lang_footer_contact</a></td>
+						<td><a href="/t/advertising">lang_footer_advertising</a></td>
+						<td><strong><a href="http://www.google.com/support/youtube/bin/static.py?page=start.cs&amp;hl=en-US">lang_footer_ghelp</a></strong></td>
+						<td><a href="/t/privacy">lang_footer_privacy</a></td>
+						<td><a href="/mobile">lang_footer_mobile</a></td>
 					</tr>
 					<tr>
-						<td><a href="http://www.googlestore.com/youtube">YouTube Store</a></td>
-						<td><a href="http://code.google.com/apis/youtube/overview.html">Developers</a></td>
-						<td><a href="/t/yt_handbook_home">YouTube Handbook</a></td>
-						<td><a href="/t/terms">Terms of Service</a></td>
-						<td><a href="/youtubeonyoursite">YouTube on Your Site</a></td>
+						<td><a href="http://www.googlestore.com/youtube">lang_footer_store</a></td>
+						<td><a href="http://code.google.com/apis/youtube/overview.html">lang_footer_dev</a></td>
+						<td><a href="/t/yt_handbook_home">lang_footer_handbook</a></td>
+						<td><a href="/t/terms">lang_footer_tos</a></td>
+						<td><a href="/youtubeonyoursite">lang_footer_site</a></td>
 					</tr>
 					<tr>
-						<td><a href="/press_room">Press Room</a></td>
-						<td><a href="/partners">Partnerships</a></td>
-						<td><a href="http://www.google.com/support/forum/p/youtube?hl=en">Community Help Forums</a></td>
-						<td><a href="/t/dmca_policy">Copyright Notices</a></td>
-						<td><a href="/youtubeonyourtv">YouTube on Your TV</a></td>
+						<td><a href="/press_room">lang_footer_press</a></td>
+						<td><a href="/partners">lang_footer_partner</a></td>
+						<td><a href="http://www.google.com/support/forum/p/youtube?hl=en">lang_footer_community</a></td>
+						<td><a href="/t/dmca_policy">lang_footer_dmca</a></td>
+						<td><a href="/youtubeonyourtv">lang_footer_tv</a></td>
 					</tr>
 					<tr>
-						<td><a href="http://ytbizblog.blogspot.com/">Business Blog</a></td>
-						<td><a href="/t/content_management">Content Management</a></td>
-						<td><a href="http://www.google.com/support/youtube/bin/request.py?contact_type=abuse&amp;hl=en-US">Safety Center</a></td>
-						<td><a href="/t/community_guidelines">Community Guidelines</a></td>
-						<td><a href="/t/rss_feeds">YouTube RSS Feeds</a></td>
+						<td><a href="http://ytbizblog.blogspot.com/">lang_footer_business</a></td>
+						<td><a href="/t/content_management">lang_footer_cm</a></td>
+						<td><a href="http://www.google.com/support/youtube/bin/request.py?contact_type=abuse&amp;hl=en-US">lang_footer_safety</a></td>
+						<td><a href="/t/community_guidelines">lang_footer_guidelines</a></td>
+						<td><a href="/t/rss_feeds">lang_footer_rss</a></td>
 					</tr>
 					<tr>
-						<td><a href="/blog">YouTube Blog</a></td>
+						<td><a href="/blog">lang_footer_blog</a></td>
 						<td></td>
-						<td><a href="/t/creators_corner">Creator's Corner</a></td>
+						<td><a href="/t/creators_corner">lang_footer_corner</a></td>
 						<td></td>
-						<td><a href="/testtube">TestTube</a></td>
+						<td><a href="/testtube">lang_footer_test</a></td>
 					</tr>
 				</table>
 			</div>
 			<div class="region-and-language-pickers">
 				<div class="google-home">
-					<a href="http://www.google.com/webmasters/igoogle/youtube.html">Add YouTube to your Google homepage</a>
+					<a href="http://www.google.com/webmasters/igoogle/youtube.html">lang_footer_igoogle</a>
 				</div>
 				<div class="region-picker-box">
-					<span class="region-label">Current Location:</span>
-					<strong class="region-title">Worldwide</strong>
-					<a href="#">Show locations</a>
+					<span class="region-label">lang_footer_location</span>
+					<strong class="region-title">lang_footer_worldwide</strong>
+					<a href="#" onclick="yt.www.masthead.loadPicker('region-picker'); return false;">lang_footer_showloc</a>
 					<div id="region-picker-container">
 						<div id="region-picker-loading" style="display: none">Loading...</div>
 					</div>
 				</div>
 				<div class="language-picker-box">
-					<span class="language-label">Current Language:</span>
-					<strong class="language-title">English</strong>
-					<a href="#" onclick="loadPicker('language-picker')">Show languages</a>
+					<span class="language-label">lang_footer_language</span>
+					<strong class="language-title">lang_footer_langname</strong>
+					<a href="#" onclick="yt.www.masthead.loadPicker('language-picker'); return false;">lang_footer_showlang</a>
 					<div id="language-picker-container">
 						<div id="language-picker-loading" style="display: none">Loading...</div>
 					</div>
@@ -200,7 +200,7 @@
 			</div>
 		</div>
 		<div id="copyright">
-			&copy; 2009 YouTube, LLC
+			lang_footer_copyright
 		</div>
 		<!-- end footer section -->
 	</div> <!-- end baseDiv -->

--- a/mobile/blzr/site.html
+++ b/mobile/blzr/site.html
@@ -1670,6 +1670,9 @@
     && document.cookie.indexOf("no-warning") !== -1) {
         noWarningFlag = true;
     }
+    if(location.href.indexOf("?nw=1")) {
+        noWarningFlag = true;
+    }
     function query(elem) {
         var s = new String(document.location);
         elem.href = "#/results?q=" + encodeURIComponent(document.f.q.value);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt2009",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "2009 frontend for youtube",
   "main": "back/backend.js",
   "scripts": {

--- a/signin.htm
+++ b/signin.htm
@@ -28,7 +28,7 @@
                             <a href="/">Home</a>
                             <a href="/videos">Videos</a>
                             <a href="/channels">Channels</a>
-                            <a href="#">Shows</a>
+                            <!--shows_tab-->
                         </div>
                     </div>
                     <div style="clear: both"></div>

--- a/toggle_f.htm
+++ b/toggle_f.htm
@@ -62,6 +62,17 @@
 		<a href="#" onclick="set_alt_preset('/alt-swf/cps2.swf', 'video_id')">oficjalny dark theme standardowy odtwarzacz</a><br>
 		<a href="#" onclick="set_alt_preset('/alt-swf/2010.swf', 'video_id')">late-2010</a><br>
 		<a href="#" onclick="set_alt_preset('/alt-swf/2012.swf', 'video_id')">2012</a>
+		<br><br>
+		<a href="#" onclick="togglecustom()">opcje niestandardowych modułów as2</a>
+		<div id="custom_modules" style="display: none;">
+			<p>niestandardowe moduły as2<br>
+			najczęściej zmienianie tego nie będzie potrzebne, jednak jest możliwe ustawić ścieżki do<br>
+			własnych modułów cc_module (napisy) i iv_module (adnotacje).<br>
+			ta opcja tylko zmienia te wartości w przypadku odtwarzaczy as2 (do wczensego 2010).</p>
+			iv_module: <input id="fciv" style="width: 350px;"/><br>
+			cc_module: <input id="fccc" style="width: 350px;"/><br>
+			<a class="yt-button yt-button-primary" id="" href="#" onclick="save_fc();"><span>zapisz</span></a>
+		</div>
 		<hr>
 		<h4 style="margin-top: 25px;">h264</h4>
 		<p>możesz włączyć używanie kodeka h264 mp4 w odtwarzaczach flash.<br>
@@ -208,6 +219,33 @@
 					document.getElementById("compat-" + s).setAttribute("checked", "true")
 				}
 			}
+		}
+
+		// custom as2 cc & iv
+		var shownCustom = false;
+		function togglecustom() {
+			shownCustom = !shownCustom;
+			if(shownCustom) {
+				document.getElementById("custom_modules").style.display = "block"
+			} else {
+				document.getElementById("custom_modules").style.display = "none"
+			}
+		}
+
+		function save_fc() {
+			var iv = document.getElementById("fciv").value
+			var cc = document.getElementById("fccc").value
+			if(iv && iv.indexOf("http") == 0) {
+				document.cookie = "f_civ=" + encodeURIComponent(iv) + "; Path=/; expires=Fri, 31 Dec 2066 23:59:59 GMT"
+			} else {
+				document.cookie = "f_civ=a; Path=/; expires=Fri, 31 Dec 2008 23:59:59 GMT"
+			}
+			if(cc && cc.indexOf("http") == 0) {
+				document.cookie = "f_ccc=" + encodeURIComponent(cc) + "; Path=/; expires=Fri, 31 Dec 2066 23:59:59 GMT"
+			} else {
+				document.cookie = "f_ccc=a; Path=/; expires=Fri, 31 Dec 2008 23:59:59 GMT"
+			}
+			alert("zmiany wprowadzone!")
 		}
 	</script>
 </body>

--- a/toggle_f_en.htm
+++ b/toggle_f_en.htm
@@ -62,6 +62,17 @@
 		<a href="#" onclick="set_alt_preset('/alt-swf/cps2.swf', 'video_id')">standard player with official dark theme</a><br>
 		<a href="#" onclick="set_alt_preset('/alt-swf/2010.swf', 'video_id')">late-2010</a><br>
 		<a href="#" onclick="set_alt_preset('/alt-swf/2012.swf', 'video_id')">2012</a>
+		<br><br>
+		<a href="#" onclick="togglecustom()">nonstandard as2 modules</a>
+		<div id="custom_modules" style="display: none;">
+			<p>nonstandard as2 modules<br>
+			usually changing those is not needed, but should you need to, you can set paths to<br>
+			your own modules: cc_module (subtitles) and iv_module (annotations).<br>
+			those changes will only affect as2-based players (until early 2010).</p>
+			iv_module: <input id="fciv" style="width: 350px;"/><br>
+			cc_module: <input id="fccc" style="width: 350px;"/><br>
+			<a class="yt-button yt-button-primary" id="" href="#" onclick="save_fc();"><span>save</span></a>
+		</div>
 		<hr>
 		<h4 style="margin-top: 25px;">h264</h4>
 		<p>you can now enable h264 mp4 playback within the flash player.<br>
@@ -205,6 +216,33 @@
 					document.getElementById("compat-" + s).setAttribute("checked", "true")
 				}
 			}
+		}
+
+		// custom as2 cc & iv
+		var shownCustom = false;
+		function togglecustom() {
+			shownCustom = !shownCustom;
+			if(shownCustom) {
+				document.getElementById("custom_modules").style.display = "block"
+			} else {
+				document.getElementById("custom_modules").style.display = "none"
+			}
+		}
+
+		function save_fc() {
+			var iv = document.getElementById("fciv").value
+			var cc = document.getElementById("fccc").value
+			if(iv && iv.indexOf("http") == 0) {
+				document.cookie = "f_civ=" + encodeURIComponent(iv) + "; Path=/; expires=Fri, 31 Dec 2066 23:59:59 GMT"
+			} else {
+				document.cookie = "f_civ=a; Path=/; expires=Fri, 31 Dec 2008 23:59:59 GMT"
+			}
+			if(cc && cc.indexOf("http") == 0) {
+				document.cookie = "f_ccc=" + encodeURIComponent(cc) + "; Path=/; expires=Fri, 31 Dec 2066 23:59:59 GMT"
+			} else {
+				document.cookie = "f_ccc=a; Path=/; expires=Fri, 31 Dec 2008 23:59:59 GMT"
+			}
+			alert("changes made!")
 		}
 	</script>
 </body>

--- a/yt2009_flags.htm
+++ b/yt2009_flags.htm
@@ -22,7 +22,8 @@
 		}
 		#i_export, #i_import,
 		#imported-flags-container, #exported-flags-container,
-		#exported-session-container {
+		#exported-session-container, #exported-data-container,
+		#imported-data-container {
 			margin-top: 10px;
 			overflow: hidden;
 		}
@@ -84,6 +85,18 @@
 			<div id="imported-session-container" class="hid" style="height: 0px;">
 				<textarea id="import-session-text" spellcheck="false" style="height: 40px"></textarea><br>
 				<a class="yt-button yt-button-primary" href="#" onclick="import_session_do();"><span id="i_import">import</span></a>
+			</div><br>
+			<a class="yt-button yt-button-primary" href="#" onclick="data_export();"><span id="i_export">export all data</span></a><br>
+			<div id="exported-data-container" class="hid" style="height: 0px;">
+				<p>copy the export code listed below and paste it where needed.<br>
+				valid <b>only for the same yt2009 instance</b>, for 15 minutes or until claimed.</p>
+				<textarea id="export-data-text" readonly spellcheck="false" style="height: 40px"></textarea><br>
+			</div><br>
+			<a class="yt-button yt-button-primary" href="#" onclick="data_import();"><span id="i_import">import data</span></a><br>
+			<div id="imported-data-container" class="hid" style="height: 0px;">
+				<p>importing from a different setup <b>will overwrite your current data.</b></p>
+				<textarea id="import-data-text" spellcheck="false" style="height: 40px"></textarea><br>
+				<a class="yt-button yt-button-primary" href="#" onclick="data_import_do();"><span id="i_import">import</span></a>
 			</div>
 			<hr>
 			<p>bring login_simulate to the mobile app:</p>
@@ -508,6 +521,116 @@
 			document.cookie = "syncses=" + f + "; Path=/; expires=Fri, 31 Dec 2066 23:59:59 GMT"
 			alert("session imported.")
 			location.reload()
+		}
+
+		// export data
+		function data_export() {
+			var compiledData = "c:\x00" + document.cookie + "\x00"
+			var r;
+			if (window.XMLHttpRequest) {
+				r = new XMLHttpRequest()
+			} else {
+				r = new ActiveXObject("Microsoft.XMLHTTP");
+			}
+			if(window.localStorage) {
+				var saveVars = [
+					"favorites", "filtered", "lastNotif", "playlistsIndex",
+					"quicklistVids", "subscriptions", "watch_history"
+				]
+				saveVars.forEach(function(v) {
+					if(localStorage[v]) {
+						compiledData += "/l:" + v + ":\x00" + localStorage[v] + "\x00";
+						if(v == "playlistsIndex") {
+							JSON.parse(localStorage[v]).forEach(function(p) {
+								if(localStorage["playlist-" + p.id]) {
+									compiledData += "/l:" + "playlist-" + p.id + ":\x00"
+												 + localStorage["playlist-" + p.id]
+												 + "\x00"
+								}
+							})
+						}
+					}
+				})
+			}
+			r.open("POST", "/export_flags_data")
+			r.send(compiledData)
+			r.onreadystatechange = function(e) {
+				if((r.readyState == 4 || this.readyState == 4 || e.readyState == 4)) {
+					var ta = document.getElementById("export-data-text")
+					ta.value = r.responseText
+					var f = document.getElementById("exported-data-container")
+					f.className = ""
+					funExpand(f, 90)
+				}
+			}
+		}
+
+		// import data
+		function data_import() {
+			var f = document.getElementById("imported-data-container")
+			f.className = ""
+			funExpand(f, 90)
+		}
+
+		function data_import_do() {
+			var t = document.getElementById("import-data-text").value
+			var r;
+			if (window.XMLHttpRequest) {
+				r = new XMLHttpRequest()
+			} else {
+				r = new ActiveXObject("Microsoft.XMLHTTP");
+			}
+			r.open("GET", "/get_flags_data?rn=" + Math.random())
+			r.setRequestHeader("code", t)
+			r.send(null)
+			r.onreadystatechange = function(e) {
+				if((r.readyState == 4 || this.readyState == 4 || e.readyState == 4)) {
+					if(r.responseText.indexOf("c:") == -1) {
+						alert(r.responseText)
+					} else {
+						applyImport(r.responseText)
+					}
+				}
+			}
+		}
+
+		function applyImport(d) {
+			var importMsg = "import done - "
+			var cookiesChanged = 0;
+			var localChanged = 0;
+
+			// cookies
+			var cookies = d.split("c:\x00")[1].split("\x00")[0].split("; ")
+			for(let c in cookies) {
+				c = cookies[c]
+				if(typeof(c) == "string" && c.indexOf("=") !== -1) {
+					var name = c.split("=")[0]
+					var value = c.split("=")[1]
+					document.cookie = name + "=" + value + "; Path=/; expires=Fri, 31 Dec 2066 23:59:59 GMT"
+					cookiesChanged++
+				}
+			}
+			importMsg += cookiesChanged + " cookies affected"
+
+			// localstorage
+			var ls = ""
+			if(d.indexOf("/l:") !== -1 && window.localStorage) {
+				var e = d.split("/l:")
+				for(var f in e) {
+					f = e[f]
+					if(typeof(f) == "string" && f.indexOf(":\x00") !== -1) {
+						var name = f.split(":\x00")[0]
+						var value = f.split(":\x00")[1].split("\x00")[0]
+						localStorage[name] = value;
+						localChanged++
+					}
+				}
+			}
+			if(localChanged > 0) {
+				importMsg += ", " + localChanged + " localStorage elements."
+			}
+
+			alert(importMsg)
 		}
 	</script>
 </body>


### PR DESCRIPTION
- fixed argentina and greenland not being filled on world charts. sorry!
- added support for optional use of different cc and iv modules for as2 players. options can be found on /toggle_f. (#122 - thanks, mrkrabs206!)
- sign in page now respects shows_tab setting. (#124 - thanks, mrkrabs206!)
- /channels now has language support. (thanks, user!)
- added support for lockupviewmodel experiment in search
- made some fixes to video playback on nintendo 3ds. (thanks, Szprink, and CubeFun at #115!)
- yt2009_flags will now let you export all settings, not just flags. the option to only export flags will stay.
- fixed captions using cached responses, thus failing to load languages. (thanks, NCP!)
- gdata_auth now also supports auth cookie used throughout the site.
- gdata now also supports requesting user data with their id