### PR TITLE
use ANDROID /player for video data

### DIFF
--- a/back/backend_wrap.js
+++ b/back/backend_wrap.js
@@ -1,4 +1,5 @@
 const child_process = require("child_process")
+const fetch = require("node-fetch")
 const fs = require("fs")
 let yt2009_process;
 

--- a/back/yt2009exports.js
+++ b/back/yt2009exports.js
@@ -4,7 +4,8 @@ let data = {
     "context": {},
     "fileDownloadStatus": {},
     "masterWs": false,
-    "dataFetches": {}
+    "dataFetches": {},
+    "players": {}
 }
 let fileDownloadListeners = {
 
@@ -18,6 +19,14 @@ module.exports = {
 
     "read": function() {
         return data;
+    },
+
+    "extendWrite": function(name, property, value) {
+        data[name][property] = value;
+    },
+
+    "delete": function(name, value) {
+        delete data[name][value]
     },
 
     "updateFileDownload": function(id, status) {

--- a/back/yt2009templates.js
+++ b/back/yt2009templates.js
@@ -813,7 +813,7 @@ module.exports = {
         <media:group>
             <media:content url='http://www.youtube.com/v/${video.id}?f=playlists&amp;app=youtube_gdata' type='application/x-shockwave-flash' medium='video' isDefault='true' expression='full' duration='583' yt:format='5'/>
             <media:credit role='uploader' scheme='urn:youtube' yt:type='partner'>sltrib</media:credit>
-            <media:description type='plain'>${video.description}</media:description>
+            <media:description type='plain'>${video.description || ""}</media:description>
             <media:keywords>salt, lake, tribune, utah, tourist, business</media:keywords>
             <media:player url='http://www.youtube.com/watch?v=rInvb982mYU&amp;feature=youtube_gdata'/>
             <media:thumbnail url='http://i.ytimg.com/vi/${video.id}/default.jpg' height='90' width='120' time='00:00:00.500'/>

--- a/back/yt2009utils.js
+++ b/back/yt2009utils.js
@@ -1273,6 +1273,14 @@ module.exports = {
 
         yt2009exports.updateFileDownload(fname, 1)
 
+        if(yt2009exports.read().players[id]) {
+            parseResponse(yt2009exports.read().players[id])
+            setTimeout(() => {
+                yt2009exports.delete("players", id)
+            }, 200)
+            return;
+        }
+
         let rHeaders = JSON.parse(JSON.stringify(constants.headers))
         rHeaders["user-agent"] = "com.google.android.youtube/19.02.39 (Linux; U; Android 14) gzip"
         if(yt2009tvsignin.needed() && yt2009tvsignin.getTvData().accessToken) {

--- a/yt2009_flags.htm
+++ b/yt2009_flags.htm
@@ -540,6 +540,7 @@
 					"favorites", "filtered", "lastNotif", "playlistsIndex",
 					"quicklistVids", "subscriptions", "watch_history"
 				]
+				v = saveVars[v]
 				for(var v in saveVars) {
 					if(localStorage[v]) {
 						compiledData += "/l:" + v + ":" + separatorChar + localStorage[v] + separatorChar;


### PR DESCRIPTION
oauth authorization stopped working for WEB and a few other clients. as much data as possible is now pulled from ANDROID to display the initial watch page.

the same ANDROID response is now also stored for a short period to not repeat the request for video downloads.

category is hardcoded to People & Blogs for now if can't be pulled, to fix whenever i can (prob around next week)